### PR TITLE
Added exception handling for malformed request JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,12 @@ module.exports = {
         var ticketreq = https.request(settings, function (ticketres) {
             ticketres.on('data', function (d) {
                 //Parse ticket response
-                var ticket = JSON.parse(d.toString());
+                try {
+                    var ticket = JSON.parse(d.toString());
+                } catch(e) {
+                    res.end('Invalid request JSON');
+                    return;
+                }
 
                 //Build redirect including ticket
                 if (ticket.TargetUri.indexOf("?") > 0) {


### PR DESCRIPTION
When testing out this code, I noted that a malformed request would crash the node-js app at the point where it tried to parse the incoming JSON string.
A simple try-catch around the call to the JSON parser seems to do the trick.