### PR TITLE
Allow certificate contents to be defined inline

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -83,6 +83,17 @@ ADVANCED USAGE
        'PassPhrase': ''
      }
 
+ - You can also include the certificate contents directly in the options like
+   this:
+
+     var options = {
+       'CertificateContents': '-----BEGIN CERTIFICATE-----\r\nABCD...'
+       'CertificateKeyContents': '-----BEGIN RSA PRIVATE KEY-----\r\nABCD...'
+     }
+
+   If you do this, no files will be checked for certificates and the
+   Certificate and/or CertificateKey options will be ignored.
+
  - When Qlik Sense is redirecting to a custom authentication module it passes
    proxyRestUri and targetId as parameters. These are normally handled by the
    function automatically, but for scenarios where it might be necessary to


### PR DESCRIPTION
Allow entire certificate contents to be passed in options

This is useful if your certificate contents are being stored
in memory and you don't want to have to write them to and 
read them from disk.